### PR TITLE
Allow for children elements

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,3 @@
-index2.js
 ReactNativeStatusBarAlertExample/node_modules
 ReactNativeStatusBarAlertExample/.expo/**
 ReactNativeStatusBarAlertExample/npm-debug.*

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ A status bar alert (e.g. in-call, recording, navigating) for React Native
 
 ## Install
 
-`npm install react-native-statusbar-alert --save`
+`npm install react-native-statusbar-alert --save` or `yarn add react-native-statusbar-alert`
 
 ## Usage
 
@@ -49,6 +49,25 @@ A status bar alert (e.g. in-call, recording, navigating) for React Native
 
 ![press](screenshots/react-native-statusbar-alert-press.mov.gif)
 
+### Children
+
+```js
+<StatusBarAlert
+  visible={true}
+  height={68}
+  style={{
+    padding: 5
+  }}
+>
+  <Image
+    style={{ width: 66, height: 58 }}
+    source={{
+      uri: 'https://facebook.github.io/react-native/img/header_logo.png'
+    }}
+  />
+</StatusBarAlert>
+```
+
 ## Props
 
 | Name            | Description                     | Required    | Type                      | Default
@@ -60,10 +79,13 @@ A status bar alert (e.g. in-call, recording, navigating) for React Native
 | backgroundColor | background color                | false       | [color][1]                | `'#3DD84C'`
 | highlightColor  | color on press and pulse        | false       | [color][1]                | `darken(this.props.backgroundColor, 0.9)`
 | color           | text color                      | false       | [color][1]                | `'white'`
+| height          | height of children container    | false       | int                       | 20
 | statusbarHeight | [custom status bar height][2]   | false       | int                       | 20
+| style           | styles for children container   | false       | [style object][3]         | `{}`
 
-[1]: https://facebook.github.io/react-native/docs/colors.html  "Colors"
+[1]: https://facebook.github.io/react-native/docs/colors.html  "React Native Colors"
 [2]: https://github.com/brentvatne/react-native-status-bar-size "react-native-status-bar-size"
+[3]: https://facebook.github.io/react-native/docs/style.html  "React Native Style"
 
 ## Usage with Navigator on iOS
 

--- a/ReactNativeStatusBarAlertExample/App.js
+++ b/ReactNativeStatusBarAlertExample/App.js
@@ -1,69 +1,109 @@
 import React from 'react';
-import { 
-  StyleSheet,
-  View,
-  Text,
-  Button,
-  Image,
-  StatusBar,
-} from 'react-native';
+import { StyleSheet, View, Text, Button, Image, StatusBar } from 'react-native';
 import StatusBarAlert from 'react-native-statusbar-alert';
 
 export default class App extends React.Component {
-  
-  state = {
-    visible: true,
-    barStyle: 'light-content'
-  }
-  
-  render() {
-    return (
-      <View style={styles.container}>
-        <StatusBar 
-          barStyle="light-content"
-        />
-        <StatusBarAlert
-          visible={this.state.visible}
-          message="Alert!"
-          pulse="background"
-          onPress={() => {
-            this.setState({ 
-              visible: !this.state.visible,
-              barStyle: this.state.barStyle === 'light-content' ? 'dark-content' : 'light-content'
-            });
-          }}
-        />
-        <View style={styles.body}>
-          <Text>Open up App.js to start working on your app!</Text>
-          <Text>Changes you make will automatically reload.</Text>
-          <Text>Shake your phone to open the developer menu.</Text>
-          <Button
-            onPress={() => {
-              this.setState({ 
-                visible: !this.state.visible,
-                barStyle: this.state.barStyle === 'light-content' ? 'dark-content' : 'light-content'
-              }, () => {
-                StatusBar.setBarStyle(this.state.barStyle)
-              });
-            }}
-            title="Toggle alert"
-            color="#3DD84C"
-            accessibilityLabel="Toggle alert"
-          />
-        </View>
-      </View>
-    );
-  }
-  
+	state = {
+		visible: false,
+		barStyle: 'dark-content',
+		content: null
+	};
+
+	render() {
+		StatusBar.setBarStyle(this.state.barStyle);
+		return (
+			<View style={styles.container}>
+				<StatusBar barStyle={this.state.barStyle} />
+				{this.state.content}
+				<View style={styles.body}>
+					<Text>Welcome to the react-native-statusbar-alert example app</Text>
+					<Button
+						onPress={() => {
+							this.setState({
+								visible: !this.state.visible,
+								barStyle:
+									this.state.barStyle === 'light-content'
+										? 'dark-content'
+										: 'light-content',
+								content: this.imageAlert()
+							});
+						}}
+						title="Toggle image alert"
+						color="#3DD84C"
+						accessibilityLabel="Toggle image alert"
+					/>
+					<Button
+						onPress={() => {
+							this.setState({
+								visible: !this.state.visible,
+								barStyle:
+									this.state.barStyle === 'light-content'
+										? 'dark-content'
+										: 'light-content',
+								content: this.textAlert()
+							});
+						}}
+						title="Toggle text alert"
+						color="#3DD84C"
+						accessibilityLabel="Toggle text alert"
+					/>
+				</View>
+			</View>
+		);
+	}
+
+	textAlert = () => (
+		<StatusBarAlert
+			visible={!this.state.visible}
+			message="Alert!"
+			pulse="background"
+			onPress={() => {
+				this.setState({
+					visible: !this.state.visible,
+					barStyle:
+						this.state.barStyle === 'light-content'
+							? 'dark-content'
+							: 'light-content'
+				});
+			}}
+		/>
+	);
+
+	imageAlert = () => (
+		<StatusBarAlert
+			visible={!this.state.visible}
+			pulse="background"
+			height={68}
+			style={{
+				padding: 5
+			}}
+		>
+			<Image
+				style={{ width: 66, height: 58 }}
+				source={{
+					uri: 'https://facebook.github.io/react-native/img/header_logo.png'
+				}}
+				onPress={() => {
+					this.setState({
+						visible: !this.state.visible,
+						barStyle:
+							this.state.barStyle === 'light-content'
+								? 'dark-content'
+								: 'light-content'
+					});
+				}}
+			/>
+		</StatusBarAlert>
+	);
 }
 
 const styles = StyleSheet.create({
-  container: {
-    flex: 1
-  },
-  body: {
-    flex: 1,
-    alignItems: 'center',
-    justifyContent: 'center',
-  }
+	container: {
+		flex: 1
+	},
+	body: {
+		flex: 1,
+		alignItems: 'center',
+		justifyContent: 'center'
+	}
 });

--- a/ReactNativeStatusBarAlertExample/package.json
+++ b/ReactNativeStatusBarAlertExample/package.json
@@ -4,6 +4,7 @@
   "private": true,
   "devDependencies": {
     "jest-expo": "^21.0.2",
+    "react-devtools": "^2.5.2",
     "react-native-scripts": "1.5.0",
     "react-test-renderer": "16.0.0-alpha.12"
   },

--- a/ReactNativeStatusBarAlertExample/yarn.lock
+++ b/ReactNativeStatusBarAlertExample/yarn.lock
@@ -60,6 +60,10 @@
     component-type "^1.2.1"
     join-component "^1.1.0"
 
+"@types/node@^8.0.24":
+  version "8.0.34"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-8.0.34.tgz#55f801fa2ddb2a40dd6dfc15ecfe1dde9c129fe9"
+
 Base64@~0.1.3:
   version "0.1.4"
   resolved "https://registry.yarnpkg.com/Base64/-/Base64-0.1.4.tgz#e9f6c6bef567fd635ea4162ab14dd329e74aa6de"
@@ -155,6 +159,12 @@ analytics-node@^2.1.0:
     superagent "^3.5.0"
     superagent-retry "^0.6.0"
 
+ansi-align@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/ansi-align/-/ansi-align-2.0.0.tgz#c36aeccba563b89ceb556f3690f0b1d9e3547f7f"
+  dependencies:
+    string-width "^2.0.0"
+
 ansi-escapes@^1.4.0:
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/ansi-escapes/-/ansi-escapes-1.4.0.tgz#d3a8a83b319aa67793662b13e761c7911422306e"
@@ -244,6 +254,10 @@ array-equal@^1.0.0:
 array-filter@~0.0.0:
   version "0.0.1"
   resolved "https://registry.yarnpkg.com/array-filter/-/array-filter-0.0.1.tgz#7da8cf2e26628ed732803581fd21f67cacd2eeec"
+
+array-find-index@^1.0.1:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/array-find-index/-/array-find-index-1.0.2.tgz#df010aa1287e164bbda6f9723b0a96a1ec4187a1"
 
 array-flatten@1.1.1:
   version "1.1.1"
@@ -1133,6 +1147,18 @@ boom@5.x.x:
   dependencies:
     hoek "4.x.x"
 
+boxen@^1.2.1:
+  version "1.2.1"
+  resolved "https://registry.yarnpkg.com/boxen/-/boxen-1.2.1.tgz#0f11e7fe344edb9397977fc13ede7f64d956481d"
+  dependencies:
+    ansi-align "^2.0.0"
+    camelcase "^4.0.0"
+    chalk "^2.0.1"
+    cli-boxes "^1.0.0"
+    string-width "^2.0.0"
+    term-size "^1.2.0"
+    widest-line "^1.0.0"
+
 bplist-creator@0.0.7:
   version "0.0.7"
   resolved "https://registry.yarnpkg.com/bplist-creator/-/bplist-creator-0.0.7.tgz#37df1536092824b87c42f957b01344117372ae45"
@@ -1234,13 +1260,32 @@ camel-case@^1.1.1:
     sentence-case "^1.1.1"
     upper-case "^1.1.1"
 
+camelcase-keys@^2.0.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/camelcase-keys/-/camelcase-keys-2.1.0.tgz#308beeaffdf28119051efa1d932213c91b8f92e7"
+  dependencies:
+    camelcase "^2.0.0"
+    map-obj "^1.0.0"
+
 camelcase@^1.0.2:
   version "1.2.1"
   resolved "https://registry.yarnpkg.com/camelcase/-/camelcase-1.2.1.tgz#9bb5304d2e0b56698b2c758b08a3eaa9daa58a39"
 
+camelcase@^2.0.0:
+  version "2.1.1"
+  resolved "https://registry.yarnpkg.com/camelcase/-/camelcase-2.1.1.tgz#7c1d16d679a1bbe59ca02cacecfb011e201f5a1f"
+
 camelcase@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/camelcase/-/camelcase-3.0.0.tgz#32fc4b9fcdaf845fcdf7e73bb97cac2261f0ab0a"
+
+camelcase@^4.0.0:
+  version "4.1.0"
+  resolved "https://registry.yarnpkg.com/camelcase/-/camelcase-4.1.0.tgz#d545635be1e33c542649c69173e5de6acfae34dd"
+
+capture-stack-trace@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/capture-stack-trace/-/capture-stack-trace-1.0.0.tgz#4a6fa07399c26bba47f0b2496b4d0fb408c5550d"
 
 caseless@~0.12.0:
   version "0.12.0"
@@ -1295,6 +1340,10 @@ change-case@^2.3.0:
 ci-info@^1.0.0:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/ci-info/-/ci-info-1.1.1.tgz#47b44df118c48d2597b56d342e7e25791060171a"
+
+cli-boxes@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/cli-boxes/-/cli-boxes-1.0.0.tgz#4fa917c3e59c94a004cd61f8ee509da651687143"
 
 cli-cursor@^2.1.0:
   version "2.1.0"
@@ -1405,13 +1454,24 @@ concat-map@0.0.1:
   version "0.0.1"
   resolved "https://registry.yarnpkg.com/concat-map/-/concat-map-0.0.1.tgz#d8a96bd77fd68df7793a73036a3ba0d5405d477b"
 
-concat-stream@^1.6.0:
+concat-stream@1.6.0, concat-stream@^1.6.0:
   version "1.6.0"
   resolved "https://registry.yarnpkg.com/concat-stream/-/concat-stream-1.6.0.tgz#0aac662fd52be78964d5532f694784e70110acf7"
   dependencies:
     inherits "^2.0.3"
     readable-stream "^2.2.2"
     typedarray "^0.0.6"
+
+configstore@^3.0.0:
+  version "3.1.1"
+  resolved "https://registry.yarnpkg.com/configstore/-/configstore-3.1.1.tgz#094ee662ab83fad9917678de114faaea8fcdca90"
+  dependencies:
+    dot-prop "^4.1.0"
+    graceful-fs "^4.1.2"
+    make-dir "^1.0.0"
+    unique-string "^1.0.0"
+    write-file-atomic "^2.0.0"
+    xdg-basedir "^3.0.0"
 
 connect-timeout@~1.6.2:
   version "1.6.2"
@@ -1524,6 +1584,12 @@ crc@3.3.0:
   version "3.3.0"
   resolved "https://registry.yarnpkg.com/crc/-/crc-3.3.0.tgz#fa622e1bc388bf257309082d6b65200ce67090ba"
 
+create-error-class@^3.0.0:
+  version "3.0.2"
+  resolved "https://registry.yarnpkg.com/create-error-class/-/create-error-class-3.0.2.tgz#06be7abef947a3f14a30fd610671d401bca8b7b6"
+  dependencies:
+    capture-stack-trace "^1.0.0"
+
 create-react-class@^15.5.2:
   version "15.6.2"
   resolved "https://registry.yarnpkg.com/create-react-class/-/create-react-class-15.6.2.tgz#cf1ed15f12aad7f14ef5f2dfe05e6c42f91ef02a"
@@ -1559,6 +1625,10 @@ cryptiles@3.x.x:
   dependencies:
     boom "5.x.x"
 
+crypto-random-string@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/crypto-random-string/-/crypto-random-string-1.0.0.tgz#a230f64f568310e1498009940790ec99545bca7e"
+
 crypto-token@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/crypto-token/-/crypto-token-1.0.1.tgz#27c6482faf3b63c2f5da11577f8304346fe797a5"
@@ -1590,6 +1660,12 @@ csurf@~1.8.3:
     csrf "~3.0.0"
     http-errors "~1.3.1"
 
+currently-unhandled@^0.4.1:
+  version "0.4.1"
+  resolved "https://registry.yarnpkg.com/currently-unhandled/-/currently-unhandled-0.4.1.tgz#988df33feab191ef799a61369dd76c17adf957ea"
+  dependencies:
+    array-find-index "^1.0.1"
+
 dashdash@^1.12.0:
   version "1.14.1"
   resolved "https://registry.yarnpkg.com/dashdash/-/dashdash-1.14.1.tgz#853cfa0f7cbe2fed5de20326b8dd581035f6e2f0"
@@ -1610,13 +1686,13 @@ debug@*, debug@^3.1.0:
   dependencies:
     ms "2.0.0"
 
-debug@2, debug@2.6.9, debug@^2.2.0, debug@^2.6.2, debug@^2.6.3, debug@^2.6.8:
+debug@2, debug@2.6.9, debug@^2.1.3, debug@^2.2.0, debug@^2.6.2, debug@^2.6.3, debug@^2.6.8:
   version "2.6.9"
   resolved "https://registry.yarnpkg.com/debug/-/debug-2.6.9.tgz#5d128515df134ff327e90a4c93f4e077a536341f"
   dependencies:
     ms "2.0.0"
 
-debug@~2.2.0:
+debug@2.2.0, debug@~2.2.0:
   version "2.2.0"
   resolved "https://registry.yarnpkg.com/debug/-/debug-2.2.0.tgz#f87057e995b1a1f6ae6a4960664137bc56f039da"
   dependencies:
@@ -1628,7 +1704,7 @@ decache@^4.1.0:
   dependencies:
     callsite "^1.0.0"
 
-decamelize@^1.0.0, decamelize@^1.1.1:
+decamelize@^1.0.0, decamelize@^1.1.1, decamelize@^1.1.2:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/decamelize/-/decamelize-1.2.0.tgz#f6534d15148269b20352e7bee26f501f9a191290"
 
@@ -1727,6 +1803,12 @@ dot-case@^1.1.0:
   dependencies:
     sentence-case "^1.1.2"
 
+dot-prop@^4.1.0:
+  version "4.2.0"
+  resolved "https://registry.yarnpkg.com/dot-prop/-/dot-prop-4.2.0.tgz#1f19e0c2e1aa0e32797c49799f2837ac6af69c57"
+  dependencies:
+    is-obj "^1.0.0"
+
 duplexer2@0.0.2:
   version "0.0.2"
   resolved "https://registry.yarnpkg.com/duplexer2/-/duplexer2-0.0.2.tgz#c614dcf67e2fb14995a91711e5a617e8a60a31db"
@@ -1753,6 +1835,28 @@ ecdsa-sig-formatter@1.0.9:
 ee-first@1.1.1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/ee-first/-/ee-first-1.1.1.tgz#590c61156b0ae2f4f0255732a158b266bc56b21d"
+
+electron-download@^3.0.1:
+  version "3.3.0"
+  resolved "https://registry.yarnpkg.com/electron-download/-/electron-download-3.3.0.tgz#2cfd54d6966c019c4d49ad65fbe65cc9cdef68c8"
+  dependencies:
+    debug "^2.2.0"
+    fs-extra "^0.30.0"
+    home-path "^1.0.1"
+    minimist "^1.2.0"
+    nugget "^2.0.0"
+    path-exists "^2.1.0"
+    rc "^1.1.2"
+    semver "^5.3.0"
+    sumchecker "^1.2.0"
+
+electron@^1.4.15:
+  version "1.8.1"
+  resolved "https://registry.yarnpkg.com/electron/-/electron-1.8.1.tgz#19b6f39f2013e204a91a60bc3086dc7a4a07ed88"
+  dependencies:
+    "@types/node" "^8.0.24"
+    electron-download "^3.0.1"
+    extract-zip "^1.0.3"
 
 encodeurl@~1.0.1:
   version "1.0.1"
@@ -1795,7 +1899,7 @@ es6-error@^4.0.2:
   version "4.0.2"
   resolved "https://registry.yarnpkg.com/es6-error/-/es6-error-4.0.2.tgz#eec5c726eacef51b7f6b73c20db6e1b13b069c98"
 
-es6-promise@^4.0.3:
+es6-promise@^4.0.3, es6-promise@^4.0.5:
   version "4.1.1"
   resolved "https://registry.yarnpkg.com/es6-promise/-/es6-promise-4.1.1.tgz#8811e90915d9a0dba36274f0b242dbda78f9c92a"
 
@@ -1865,6 +1969,18 @@ exec-sh@^0.2.0:
   resolved "https://registry.yarnpkg.com/exec-sh/-/exec-sh-0.2.1.tgz#163b98a6e89e6b65b47c2a28d215bc1f63989c38"
   dependencies:
     merge "^1.1.3"
+
+execa@^0.7.0:
+  version "0.7.0"
+  resolved "https://registry.yarnpkg.com/execa/-/execa-0.7.0.tgz#944becd34cc41ee32a63a9faf27ad5a65fc59777"
+  dependencies:
+    cross-spawn "^5.0.1"
+    get-stream "^3.0.0"
+    is-stream "^1.1.0"
+    npm-run-path "^2.0.0"
+    p-finally "^1.0.0"
+    signal-exit "^3.0.0"
+    strip-eof "^1.0.0"
 
 exists-async@^2.0.0:
   version "2.0.0"
@@ -1970,6 +2086,15 @@ extglob@^0.3.1:
   dependencies:
     is-extglob "^1.0.0"
 
+extract-zip@^1.0.3:
+  version "1.6.5"
+  resolved "https://registry.yarnpkg.com/extract-zip/-/extract-zip-1.6.5.tgz#99a06735b6ea20ea9b705d779acffcc87cff0440"
+  dependencies:
+    concat-stream "1.6.0"
+    debug "2.2.0"
+    mkdirp "0.5.0"
+    yauzl "2.4.1"
+
 extsprintf@1.3.0, extsprintf@^1.2.0:
   version "1.3.0"
   resolved "https://registry.yarnpkg.com/extsprintf/-/extsprintf-1.3.0.tgz#96918440e3041a7a414f8c52e3c574eb3c3e1e05"
@@ -2043,6 +2168,12 @@ fbjs@^0.8.16, fbjs@^0.8.4, fbjs@^0.8.9:
     promise "^7.1.1"
     setimmediate "^1.0.5"
     ua-parser-js "^0.7.9"
+
+fd-slicer@~1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/fd-slicer/-/fd-slicer-1.0.1.tgz#8b5bcbd9ec327c5041bf9ab023fd6750f1177e65"
+  dependencies:
+    pend "~1.2.0"
 
 figures@^2.0.0:
   version "2.0.0"
@@ -2270,6 +2401,10 @@ get-caller-file@^1.0.1:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/get-caller-file/-/get-caller-file-1.0.2.tgz#f702e63127e7e231c160a80c1554acb70d5047e5"
 
+get-stdin@^4.0.1:
+  version "4.0.1"
+  resolved "https://registry.yarnpkg.com/get-stdin/-/get-stdin-4.0.1.tgz#b968c6b0a04384324902e8bf1a5df32579a450fe"
+
 get-stream@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/get-stream/-/get-stream-3.0.0.tgz#8e943d1358dc37555054ecbe2edb05aa174ede14"
@@ -2325,6 +2460,12 @@ glob@^7.0.3, glob@^7.0.5, glob@^7.1.1:
     once "^1.3.0"
     path-is-absolute "^1.0.0"
 
+global-dirs@^0.1.0:
+  version "0.1.0"
+  resolved "https://registry.yarnpkg.com/global-dirs/-/global-dirs-0.1.0.tgz#10d34039e0df04272e262cf24224f7209434df4f"
+  dependencies:
+    ini "^1.3.4"
+
 global@^4.3.0:
   version "4.3.2"
   resolved "https://registry.yarnpkg.com/global/-/global-4.3.2.tgz#e76989268a6c74c38908b1305b10fc0e394e9d0f"
@@ -2341,6 +2482,22 @@ glogg@^1.0.0:
   resolved "https://registry.yarnpkg.com/glogg/-/glogg-1.0.0.tgz#7fe0f199f57ac906cf512feead8f90ee4a284fc5"
   dependencies:
     sparkles "^1.0.0"
+
+got@^6.7.1:
+  version "6.7.1"
+  resolved "https://registry.yarnpkg.com/got/-/got-6.7.1.tgz#240cd05785a9a18e561dc1b44b41c763ef1e8db0"
+  dependencies:
+    create-error-class "^3.0.0"
+    duplexer3 "^0.1.4"
+    get-stream "^3.0.0"
+    is-redirect "^1.0.0"
+    is-retry-allowed "^1.0.0"
+    is-stream "^1.0.0"
+    lowercase-keys "^1.0.0"
+    safe-buffer "^5.0.1"
+    timed-out "^4.0.0"
+    unzip-response "^2.0.1"
+    url-parse-lax "^1.0.0"
 
 got@^7.0.0:
   version "7.1.0"
@@ -2511,6 +2668,10 @@ home-or-tmp@^2.0.0:
     os-homedir "^1.0.0"
     os-tmpdir "^1.0.1"
 
+home-path@^1.0.1:
+  version "1.0.5"
+  resolved "https://registry.yarnpkg.com/home-path/-/home-path-1.0.5.tgz#788b29815b12d53bacf575648476e6f9041d133f"
+
 hosted-git-info@^2.1.4:
   version "2.5.0"
   resolved "https://registry.yarnpkg.com/hosted-git-info/-/hosted-git-info-2.5.0.tgz#6d60e34b3abbc8313062c3b798ef8d901a07af3c"
@@ -2589,9 +2750,19 @@ immediate@^3.2.2:
   version "3.2.3"
   resolved "https://registry.yarnpkg.com/immediate/-/immediate-3.2.3.tgz#d140fa8f614659bd6541233097ddaac25cdd991c"
 
+import-lazy@^2.1.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/import-lazy/-/import-lazy-2.1.0.tgz#05698e3d45c88e8d7e9d92cb0584e77f096f3e43"
+
 imurmurhash@^0.1.4:
   version "0.1.4"
   resolved "https://registry.yarnpkg.com/imurmurhash/-/imurmurhash-0.1.4.tgz#9218b9b2b928a238b13dc4fb6b6d576f231453ea"
+
+indent-string@^2.1.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/indent-string/-/indent-string-2.1.0.tgz#8e2d48348742121b4a8218b7a137e9a52049dc80"
+  dependencies:
+    repeating "^2.0.0"
 
 indent-string@^3.0.0, indent-string@^3.1.0:
   version "3.2.0"
@@ -2608,7 +2779,7 @@ inherits@2, inherits@2.0.3, inherits@^2.0.3, inherits@~2.0.0, inherits@~2.0.1, i
   version "2.0.3"
   resolved "https://registry.yarnpkg.com/inherits/-/inherits-2.0.3.tgz#633c2c83e3da42a502f52466022480f4208261de"
 
-ini@~1.3.0:
+ini@^1.3.4, ini@~1.3.0:
   version "1.3.4"
   resolved "https://registry.yarnpkg.com/ini/-/ini-1.3.4.tgz#0537cb79daf59b59a1a517dff706c86ec039162e"
 
@@ -2717,11 +2888,22 @@ is-glob@^2.0.0, is-glob@^2.0.1:
   dependencies:
     is-extglob "^1.0.0"
 
+is-installed-globally@^0.1.0:
+  version "0.1.0"
+  resolved "https://registry.yarnpkg.com/is-installed-globally/-/is-installed-globally-0.1.0.tgz#0dfd98f5a9111716dd535dda6492f67bf3d25a80"
+  dependencies:
+    global-dirs "^0.1.0"
+    is-path-inside "^1.0.0"
+
 is-lower-case@^1.1.0:
   version "1.1.3"
   resolved "https://registry.yarnpkg.com/is-lower-case/-/is-lower-case-1.1.3.tgz#7e147be4768dc466db3bfb21cc60b31e6ad69393"
   dependencies:
     lower-case "^1.1.0"
+
+is-npm@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/is-npm/-/is-npm-1.0.0.tgz#f2fb63a65e4905b406c86072765a1a4dc793b9f4"
 
 is-number@^2.1.0:
   version "2.1.0"
@@ -2735,9 +2917,19 @@ is-number@^3.0.0:
   dependencies:
     kind-of "^3.0.2"
 
+is-obj@^1.0.0:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/is-obj/-/is-obj-1.0.1.tgz#3e4729ac1f5fde025cd7d83a896dab9f4f67db0f"
+
 is-object@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/is-object/-/is-object-1.0.1.tgz#8952688c5ec2ffd6b03ecc85e769e02903083470"
+
+is-path-inside@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/is-path-inside/-/is-path-inside-1.0.0.tgz#fc06e5a1683fbda13de667aff717bbc10a48f37f"
+  dependencies:
+    path-is-inside "^1.0.1"
 
 is-plain-obj@^1.1.0:
   version "1.1.0"
@@ -2755,11 +2947,15 @@ is-promise@^2.1.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/is-promise/-/is-promise-2.1.0.tgz#79a2a9ece7f096e80f36d2b2f3bc16c1ff4bf3fa"
 
+is-redirect@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/is-redirect/-/is-redirect-1.0.0.tgz#1d03dded53bd8db0f30c26e4f95d36fc7c87dc24"
+
 is-retry-allowed@^1.0.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/is-retry-allowed/-/is-retry-allowed-1.1.0.tgz#11a060568b67339444033d0125a61a20d564fb34"
 
-is-stream@^1.0.0, is-stream@^1.0.1:
+is-stream@^1.0.0, is-stream@^1.0.1, is-stream@^1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/is-stream/-/is-stream-1.1.0.tgz#12d4a3dd4e68e0b79ceb8dbc84173ae80d91ca44"
 
@@ -3320,6 +3516,12 @@ klaw@^1.0.0:
   optionalDependencies:
     graceful-fs "^4.1.9"
 
+latest-version@^3.0.0:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/latest-version/-/latest-version-3.1.0.tgz#a205383fea322b33b5ae3b18abee0dc2f356ee15"
+  dependencies:
+    package-json "^4.0.0"
+
 lazy-cache@^1.0.3:
   version "1.0.4"
   resolved "https://registry.yarnpkg.com/lazy-cache/-/lazy-cache-1.0.4.tgz#a1d78fc3a50474cb80845d3b3b6e1da49a446e8e"
@@ -3512,6 +3714,13 @@ lottie-react-native@2.2.0:
     prop-types "^15.5.10"
     react-native-safe-module "^1.1.0"
 
+loud-rejection@^1.0.0:
+  version "1.6.0"
+  resolved "https://registry.yarnpkg.com/loud-rejection/-/loud-rejection-1.6.0.tgz#5b46f80147edee578870f086d04821cf998e551f"
+  dependencies:
+    currently-unhandled "^0.4.1"
+    signal-exit "^3.0.0"
+
 lower-case-first@^1.0.0:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/lower-case-first/-/lower-case-first-1.0.2.tgz#e5da7c26f29a7073be02d52bac9980e5922adfa1"
@@ -3561,11 +3770,21 @@ macos-release@^1.0.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/macos-release/-/macos-release-1.1.0.tgz#831945e29365b470aa8724b0ab36c8f8959d10fb"
 
+make-dir@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/make-dir/-/make-dir-1.0.0.tgz#97a011751e91dd87cfadef58832ebb04936de978"
+  dependencies:
+    pify "^2.3.0"
+
 makeerror@1.0.x:
   version "1.0.11"
   resolved "https://registry.yarnpkg.com/makeerror/-/makeerror-1.0.11.tgz#e01a5c9109f2af79660e4e8b9587790184f5a96c"
   dependencies:
     tmpl "1.0.x"
+
+map-obj@^1.0.0, map-obj@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/map-obj/-/map-obj-1.0.1.tgz#d933ceb9205d82bdcf4886f6742bdc2b4dea146d"
 
 match-require@^2.0.0:
   version "2.1.0"
@@ -3586,6 +3805,21 @@ md5hex@^1.0.0:
 media-typer@0.3.0:
   version "0.3.0"
   resolved "https://registry.yarnpkg.com/media-typer/-/media-typer-0.3.0.tgz#8710d7af0aa626f8fffa1ce00168545263255748"
+
+meow@^3.1.0:
+  version "3.7.0"
+  resolved "https://registry.yarnpkg.com/meow/-/meow-3.7.0.tgz#72cb668b425228290abbfa856892587308a801fb"
+  dependencies:
+    camelcase-keys "^2.0.0"
+    decamelize "^1.1.2"
+    loud-rejection "^1.0.0"
+    map-obj "^1.0.1"
+    minimist "^1.1.3"
+    normalize-package-data "^2.3.4"
+    object-assign "^4.0.1"
+    read-pkg-up "^1.0.1"
+    redent "^1.0.0"
+    trim-newlines "^1.0.0"
 
 merge-descriptors@1.0.1:
   version "1.0.1"
@@ -3724,7 +3958,7 @@ minimist@0.0.8, minimist@~0.0.1:
   version "0.0.8"
   resolved "https://registry.yarnpkg.com/minimist/-/minimist-0.0.8.tgz#857fcabfc3397d2625b8228262e86aa7a011b05d"
 
-minimist@^1.1.0, minimist@^1.1.1, minimist@^1.2.0:
+minimist@^1.1.0, minimist@^1.1.1, minimist@^1.1.3, minimist@^1.2.0:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/minimist/-/minimist-1.2.0.tgz#a35008b20f41383eec1fb914f4cd5df79a264284"
 
@@ -3737,6 +3971,12 @@ mkdirp-promise@^5.0.0:
 mkdirp@*, "mkdirp@>=0.5 0", mkdirp@^0.5.1, mkdirp@~0.5.1:
   version "0.5.1"
   resolved "https://registry.yarnpkg.com/mkdirp/-/mkdirp-0.5.1.tgz#30057438eac6cf7f8c4767f38648d6697d75c903"
+  dependencies:
+    minimist "0.0.8"
+
+mkdirp@0.5.0:
+  version "0.5.0"
+  resolved "https://registry.yarnpkg.com/mkdirp/-/mkdirp-0.5.0.tgz#1d73076a6df986cd9344e15e71fcc05a4c9abf12"
   dependencies:
     minimist "0.0.8"
 
@@ -3877,7 +4117,7 @@ nopt@^4.0.1:
     abbrev "1"
     osenv "^0.1.4"
 
-normalize-package-data@^2.3.2:
+normalize-package-data@^2.3.2, normalize-package-data@^2.3.4:
   version "2.4.0"
   resolved "https://registry.yarnpkg.com/normalize-package-data/-/normalize-package-data-2.4.0.tgz#12f95a307d58352075a04907b84ac8be98ac012f"
   dependencies:
@@ -3891,6 +4131,12 @@ normalize-path@^2.0.0, normalize-path@^2.0.1:
   resolved "https://registry.yarnpkg.com/normalize-path/-/normalize-path-2.1.1.tgz#1ab28b556e198363a8c1a6f7e6fa20137fe6aed9"
   dependencies:
     remove-trailing-separator "^1.0.1"
+
+npm-run-path@^2.0.0:
+  version "2.0.2"
+  resolved "https://registry.yarnpkg.com/npm-run-path/-/npm-run-path-2.0.2.tgz#35a9232dfa35d7067b4cb2ddf2357b1871536c5f"
+  dependencies:
+    path-key "^2.0.0"
 
 npmlog@^2.0.4:
   version "2.0.4"
@@ -3908,6 +4154,18 @@ npmlog@^4.0.2:
     console-control-strings "~1.1.0"
     gauge "~2.7.3"
     set-blocking "~2.0.0"
+
+nugget@^2.0.0:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/nugget/-/nugget-2.0.1.tgz#201095a487e1ad36081b3432fa3cada4f8d071b0"
+  dependencies:
+    debug "^2.1.3"
+    minimist "^1.1.0"
+    pretty-bytes "^1.0.2"
+    progress-stream "^1.1.0"
+    request "^2.45.0"
+    single-line-log "^1.1.2"
+    throttleit "0.0.2"
 
 number-is-nan@^1.0.0:
   version "1.0.1"
@@ -4088,6 +4346,15 @@ pac-resolver@^3.0.0:
     netmask "^1.0.6"
     thunkify "^2.1.2"
 
+package-json@^4.0.0:
+  version "4.0.1"
+  resolved "https://registry.yarnpkg.com/package-json/-/package-json-4.0.1.tgz#8869a0401253661c4c4ca3da6c2121ed555f5eed"
+  dependencies:
+    got "^6.7.1"
+    registry-auth-token "^3.0.1"
+    registry-url "^3.0.3"
+    semver "^5.1.0"
+
 param-case@^1.1.0:
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/param-case/-/param-case-1.1.2.tgz#dcb091a43c259b9228f1c341e7b6a44ea0bf9743"
@@ -4130,7 +4397,7 @@ path-case@^1.1.0:
   dependencies:
     sentence-case "^1.1.2"
 
-path-exists@^2.0.0:
+path-exists@^2.0.0, path-exists@^2.1.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/path-exists/-/path-exists-2.1.0.tgz#0feb6c64f0fc518d9a754dd5efb62c7022761f4b"
   dependencies:
@@ -4143,6 +4410,14 @@ path-exists@^3.0.0:
 path-is-absolute@^1.0.0, path-is-absolute@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/path-is-absolute/-/path-is-absolute-1.0.1.tgz#174b9268735534ffbc7ace6bf53a5a9e1b5c5f5f"
+
+path-is-inside@^1.0.1:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/path-is-inside/-/path-is-inside-1.0.2.tgz#365417dede44430d1c11af61027facf074bdfc53"
+
+path-key@^2.0.0:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/path-key/-/path-key-2.0.1.tgz#411cadb574c5a140d3a4b1910d40d80cc9f40b40"
 
 path-parse@^1.0.5:
   version "1.0.5"
@@ -4167,6 +4442,10 @@ pause@0.1.0:
 pegjs@^0.10.0:
   version "0.10.0"
   resolved "https://registry.yarnpkg.com/pegjs/-/pegjs-0.10.0.tgz#cf8bafae6eddff4b5a7efb185269eaaf4610ddbd"
+
+pend@~1.2.0:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/pend/-/pend-1.2.0.tgz#7a57eb550a6783f9115331fcf4663d5c8e007a50"
 
 performance-now@^0.2.0:
   version "0.2.0"
@@ -4227,6 +4506,13 @@ preserve@^0.2.0:
   version "0.2.0"
   resolved "https://registry.yarnpkg.com/preserve/-/preserve-0.2.0.tgz#815ed1f6ebc65926f865b310c0713bcb3315ce4b"
 
+pretty-bytes@^1.0.2:
+  version "1.0.4"
+  resolved "https://registry.yarnpkg.com/pretty-bytes/-/pretty-bytes-1.0.4.tgz#0a22e8210609ad35542f8c8d5d2159aff0751c84"
+  dependencies:
+    get-stdin "^4.0.1"
+    meow "^3.1.0"
+
 pretty-format@^20.0.3:
   version "20.0.3"
   resolved "https://registry.yarnpkg.com/pretty-format/-/pretty-format-20.0.3.tgz#020e350a560a1fe1a98dc3beb6ccffb386de8b14"
@@ -4260,6 +4546,13 @@ process-nextick-args@~1.0.6:
 process@~0.5.1:
   version "0.5.2"
   resolved "https://registry.yarnpkg.com/process/-/process-0.5.2.tgz#1638d8a8e34c2f440a91db95ab9aeb677fc185cf"
+
+progress-stream@^1.1.0:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/progress-stream/-/progress-stream-1.2.0.tgz#2cd3cfea33ba3a89c9c121ec3347abe9ab125f77"
+  dependencies:
+    speedometer "~0.1.2"
+    through2 "~0.2.3"
 
 progress@^2.0.0:
   version "2.0.0"
@@ -4385,7 +4678,7 @@ raw-body@~2.1.2:
     iconv-lite "0.4.13"
     unpipe "1.0.0"
 
-rc@^1.1.7:
+rc@^1.0.1, rc@^1.1.2, rc@^1.1.6, rc@^1.1.7:
   version "1.2.1"
   resolved "https://registry.yarnpkg.com/rc/-/rc-1.2.1.tgz#2e03e8e42ee450b8cb3dce65be1bf8974e1dfd95"
   dependencies:
@@ -4402,12 +4695,23 @@ react-deep-force-update@^1.0.0:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/react-deep-force-update/-/react-deep-force-update-1.1.1.tgz#bcd31478027b64b3339f108921ab520b4313dc2c"
 
-react-devtools-core@^2.5.0:
+react-devtools-core@^2.5.0, react-devtools-core@^2.5.2:
   version "2.5.2"
   resolved "https://registry.yarnpkg.com/react-devtools-core/-/react-devtools-core-2.5.2.tgz#f97bec5afae5d9318d16778065e0c214c4d5714c"
   dependencies:
     shell-quote "^1.6.1"
     ws "^2.0.3"
+
+react-devtools@^2.5.2:
+  version "2.5.2"
+  resolved "https://registry.yarnpkg.com/react-devtools/-/react-devtools-2.5.2.tgz#b6319590b287f60dab767006e882770113fa2cae"
+  dependencies:
+    cross-spawn "^5.0.1"
+    electron "^1.4.15"
+    ip "^1.1.4"
+    minimist "^1.2.0"
+    react-devtools-core "^2.5.2"
+    update-notifier "^2.1.0"
 
 react-native-branch@2.0.0-beta.3:
   version "2.0.0-beta.3"
@@ -4649,6 +4953,13 @@ rebound@^0.0.13:
   version "0.0.13"
   resolved "https://registry.yarnpkg.com/rebound/-/rebound-0.0.13.tgz#4a225254caf7da756797b19c5817bf7a7941fac1"
 
+redent@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/redent/-/redent-1.0.0.tgz#cf916ab1fd5f1f16dfb20822dd6ec7f730c2afde"
+  dependencies:
+    indent-string "^2.1.0"
+    strip-indent "^1.0.1"
+
 redux-logger@^2.7.4:
   version "2.10.2"
   resolved "https://registry.yarnpkg.com/redux-logger/-/redux-logger-2.10.2.tgz#3c5a5f0a6f32577c1deadf6655f257f82c6c3937"
@@ -4701,6 +5012,19 @@ regexpu-core@^2.0.0:
     regenerate "^1.2.1"
     regjsgen "^0.2.0"
     regjsparser "^0.1.4"
+
+registry-auth-token@^3.0.1:
+  version "3.3.1"
+  resolved "https://registry.yarnpkg.com/registry-auth-token/-/registry-auth-token-3.3.1.tgz#fb0d3289ee0d9ada2cbb52af5dfe66cb070d3006"
+  dependencies:
+    rc "^1.1.6"
+    safe-buffer "^5.0.1"
+
+registry-url@^3.0.3:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/registry-url/-/registry-url-3.1.0.tgz#3d4ef870f73dde1d77f0cf9a381432444e174942"
+  dependencies:
+    rc "^1.0.1"
 
 regjsgen@^0.2.0:
   version "0.2.0"
@@ -4771,7 +5095,7 @@ request@2.81.0:
     tunnel-agent "^0.6.0"
     uuid "^3.0.0"
 
-request@^2.74.0, request@^2.79.0, request@^2.83.0:
+request@^2.45.0, request@^2.74.0, request@^2.79.0, request@^2.83.0:
   version "2.83.0"
   resolved "https://registry.yarnpkg.com/request/-/request-2.83.0.tgz#ca0b65da02ed62935887808e6f510381034e3356"
   dependencies:
@@ -4943,6 +5267,12 @@ sax@~1.1.1:
   version "1.1.6"
   resolved "https://registry.yarnpkg.com/sax/-/sax-1.1.6.tgz#5d616be8a5e607d54e114afae55b7eaf2fcc3240"
 
+semver-diff@^2.0.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/semver-diff/-/semver-diff-2.1.0.tgz#4bbb8437c8d37e4b0cf1a68fd726ec6d645d6d36"
+  dependencies:
+    semver "^5.0.3"
+
 "semver@2 || 3 || 4 || 5", semver@5.x, semver@^5.0.1, semver@^5.0.3, semver@^5.1.0, semver@^5.3.0:
   version "5.4.1"
   resolved "https://registry.yarnpkg.com/semver/-/semver-5.4.1.tgz#e059c09d8571f0540823733433505d3a2f00b18e"
@@ -5081,6 +5411,12 @@ simple-plist@^0.2.1:
     bplist-parser "0.1.1"
     plist "2.0.1"
 
+single-line-log@^1.1.2:
+  version "1.1.2"
+  resolved "https://registry.yarnpkg.com/single-line-log/-/single-line-log-1.1.2.tgz#c2f83f273a3e1a16edb0995661da0ed5ef033364"
+  dependencies:
+    string-width "^1.0.1"
+
 slash@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/slash/-/slash-1.0.0.tgz#c41f2f6c39fc16d1cd17ad4b5d896114ae470d55"
@@ -5177,6 +5513,10 @@ spdx-license-ids@^1.0.2:
   version "1.2.2"
   resolved "https://registry.yarnpkg.com/spdx-license-ids/-/spdx-license-ids-1.2.2.tgz#c9df7a3424594ade6bd11900d596696dc06bac57"
 
+speedometer@~0.1.2:
+  version "0.1.4"
+  resolved "https://registry.yarnpkg.com/speedometer/-/speedometer-0.1.4.tgz#9876dbd2a169d3115402d48e6ea6329c8816a50d"
+
 sprintf-js@~1.0.2:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/sprintf-js/-/sprintf-js-1.0.3.tgz#04e6926f662895354f3dd015203633b857297e2c"
@@ -5241,7 +5581,7 @@ string-width@^1.0.1, string-width@^1.0.2:
     is-fullwidth-code-point "^1.0.0"
     strip-ansi "^3.0.0"
 
-string-width@^2.1.0:
+string-width@^2.0.0, string-width@^2.1.0:
   version "2.1.1"
   resolved "https://registry.yarnpkg.com/string-width/-/string-width-2.1.1.tgz#ab93f27a8dc13d28cac815c462143a6d9012ae9e"
   dependencies:
@@ -5284,9 +5624,26 @@ strip-bom@^2.0.0:
   dependencies:
     is-utf8 "^0.2.0"
 
+strip-eof@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/strip-eof/-/strip-eof-1.0.0.tgz#bb43ff5598a6eb05d89b59fcd129c983313606bf"
+
+strip-indent@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/strip-indent/-/strip-indent-1.0.1.tgz#0c7962a6adefa7bbd4ac366460a638552ae1a0a2"
+  dependencies:
+    get-stdin "^4.0.1"
+
 strip-json-comments@~2.0.1:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/strip-json-comments/-/strip-json-comments-2.0.1.tgz#3c531942e908c2697c0ec344858c286c7ca0a60a"
+
+sumchecker@^1.2.0:
+  version "1.3.1"
+  resolved "https://registry.yarnpkg.com/sumchecker/-/sumchecker-1.3.1.tgz#79bb3b4456dd04f18ebdbc0d703a1d1daec5105d"
+  dependencies:
+    debug "^2.2.0"
+    es6-promise "^4.0.5"
 
 superagent-proxy@^1.0.2:
   version "1.0.2"
@@ -5383,6 +5740,12 @@ temp@0.8.3:
     os-tmpdir "^1.0.0"
     rimraf "~2.2.6"
 
+term-size@^1.2.0:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/term-size/-/term-size-1.2.0.tgz#458b83887f288fc56d6fffbfad262e26638efa69"
+  dependencies:
+    execa "^0.7.0"
+
 test-exclude@^4.1.1:
   version "4.1.1"
   resolved "https://registry.yarnpkg.com/test-exclude/-/test-exclude-4.1.1.tgz#4d84964b0966b0087ecc334a2ce002d3d9341e26"
@@ -5413,6 +5776,10 @@ throat@^4.1.0:
   version "4.1.0"
   resolved "https://registry.yarnpkg.com/throat/-/throat-4.1.0.tgz#89037cbc92c56ab18926e6ba4cbb200e15672a6a"
 
+throttleit@0.0.2:
+  version "0.0.2"
+  resolved "https://registry.yarnpkg.com/throttleit/-/throttleit-0.0.2.tgz#cfedf88e60c00dd9697b61fdd2a8343a9b680eaf"
+
 throttleit@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/throttleit/-/throttleit-1.0.0.tgz#9e785836daf46743145a5984b6268d828528ac6c"
@@ -5423,6 +5790,13 @@ through2@^2.0.0:
   dependencies:
     readable-stream "^2.1.5"
     xtend "~4.0.1"
+
+through2@~0.2.3:
+  version "0.2.3"
+  resolved "https://registry.yarnpkg.com/through2/-/through2-0.2.3.tgz#eb3284da4ea311b6cc8ace3653748a52abf25a3f"
+  dependencies:
+    readable-stream "~1.1.9"
+    xtend "~2.1.1"
 
 through@^2.3.6:
   version "2.3.8"
@@ -5490,6 +5864,10 @@ tr46@~0.0.3:
 tree-kill@^1.1.0:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/tree-kill/-/tree-kill-1.2.0.tgz#5846786237b4239014f05db156b643212d4c6f36"
+
+trim-newlines@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/trim-newlines/-/trim-newlines-1.0.0.tgz#5887966bb582a4503a41eb524f7d35011815a613"
 
 trim-right@^1.0.1:
   version "1.0.1"
@@ -5571,6 +5949,12 @@ ultron@~1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/ultron/-/ultron-1.1.0.tgz#b07a2e6a541a815fc6a34ccd4533baec307ca864"
 
+unique-string@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/unique-string/-/unique-string-1.0.0.tgz#9e1057cca851abb93398f8b33ae187b99caec11a"
+  dependencies:
+    crypto-random-string "^1.0.0"
+
 universalify@^0.1.0:
   version "0.1.1"
   resolved "https://registry.yarnpkg.com/universalify/-/universalify-0.1.1.tgz#fa71badd4437af4c148841e3b3b165f9e9e590b7"
@@ -5578,6 +5962,24 @@ universalify@^0.1.0:
 unpipe@1.0.0, unpipe@~1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/unpipe/-/unpipe-1.0.0.tgz#b2bf4ee8514aae6165b4817829d21b2ef49904ec"
+
+unzip-response@^2.0.1:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/unzip-response/-/unzip-response-2.0.1.tgz#d2f0f737d16b0615e72a6935ed04214572d56f97"
+
+update-notifier@^2.1.0:
+  version "2.3.0"
+  resolved "https://registry.yarnpkg.com/update-notifier/-/update-notifier-2.3.0.tgz#4e8827a6bb915140ab093559d7014e3ebb837451"
+  dependencies:
+    boxen "^1.2.1"
+    chalk "^2.0.1"
+    configstore "^3.0.0"
+    import-lazy "^2.1.0"
+    is-installed-globally "^0.1.0"
+    is-npm "^1.0.0"
+    latest-version "^3.0.0"
+    semver-diff "^2.0.0"
+    xdg-basedir "^3.0.0"
 
 upper-case-first@^1.1.0:
   version "1.1.2"
@@ -5718,11 +6120,7 @@ whatwg-encoding@^1.0.1:
   dependencies:
     iconv-lite "0.4.13"
 
-whatwg-fetch@>=0.10.0:
-  version "2.0.3"
-  resolved "https://registry.yarnpkg.com/whatwg-fetch/-/whatwg-fetch-2.0.3.tgz#9c84ec2dcf68187ff00bc64e1274b442176e1c84"
-
-whatwg-fetch@^1.0.0:
+whatwg-fetch@>=0.10.0, whatwg-fetch@^1.0.0:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/whatwg-fetch/-/whatwg-fetch-1.1.1.tgz#ac3c9d39f320c6dce5339969d054ef43dd333319"
 
@@ -5748,6 +6146,12 @@ wide-align@^1.1.0:
   resolved "https://registry.yarnpkg.com/wide-align/-/wide-align-1.1.2.tgz#571e0f1b0604636ebc0dfc21b0339bbe31341710"
   dependencies:
     string-width "^1.0.2"
+
+widest-line@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/widest-line/-/widest-line-1.0.0.tgz#0c09c85c2a94683d0d7eaf8ee097d564bf0e105c"
+  dependencies:
+    string-width "^1.0.1"
 
 win-release@^1.0.0:
   version "1.1.1"
@@ -5801,6 +6205,14 @@ write-file-atomic@^1.2.0:
     imurmurhash "^0.1.4"
     slide "^1.1.5"
 
+write-file-atomic@^2.0.0:
+  version "2.3.0"
+  resolved "https://registry.yarnpkg.com/write-file-atomic/-/write-file-atomic-2.3.0.tgz#1ff61575c2e2a4e8e510d6fa4e243cce183999ab"
+  dependencies:
+    graceful-fs "^4.1.11"
+    imurmurhash "^0.1.4"
+    signal-exit "^3.0.2"
+
 ws@^1.1.0:
   version "1.1.4"
   resolved "https://registry.yarnpkg.com/ws/-/ws-1.1.4.tgz#57f40d036832e5f5055662a397c4de76ed66bf61"
@@ -5822,6 +6234,10 @@ xcode@^0.9.1:
     pegjs "^0.10.0"
     simple-plist "^0.2.1"
     uuid "3.0.1"
+
+xdg-basedir@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/xdg-basedir/-/xdg-basedir-3.0.0.tgz#496b2cc109eca8dbacfe2dc72b603c17c5870ad4"
 
 xdl@45.0.0:
   version "45.0.0"
@@ -5988,6 +6404,12 @@ yargs@~3.10.0:
     cliui "^2.1.0"
     decamelize "^1.0.0"
     window-size "0.1.0"
+
+yauzl@2.4.1:
+  version "2.4.1"
+  resolved "https://registry.yarnpkg.com/yauzl/-/yauzl-2.4.1.tgz#9528f442dab1b2284e58b4379bb194e22e0c4005"
+  dependencies:
+    fd-slicer "~1.0.1"
 
 yesno@^0.0.1:
   version "0.0.1"

--- a/index.js
+++ b/index.js
@@ -1,228 +1,225 @@
-import React, {Component} from 'react'
-import PropTypes from 'prop-types'
+import React, { Component } from 'react';
+import PropTypes from 'prop-types';
 import {
-  Animated,
-  InteractionManager,
-  Platform,
-  StatusBar,
-  StyleSheet,
-  Text,
-  TouchableHighlight,
-  TouchableOpacity,
-  View
-} from 'react-native'
+	Animated,
+	InteractionManager,
+	Platform,
+	StatusBar,
+	StyleSheet,
+	Text,
+	TouchableHighlight,
+	TouchableOpacity,
+	View
+} from 'react-native';
 
 class StatusBarAlert extends Component {
+	constructor(props) {
+		super(props);
+		this.state = {
+			height: new Animated.Value(
+				Platform.OS === 'ios' ? (props.statusbarHeight || STATUS_BAR_HEIGHT) : 0
+			),
+			opacity: new Animated.Value(0),
+			pulse: new Animated.Value(0)
+		};
+		this.timer = null;
+	}
 
-  constructor(props) {
-    super(props)
-    this.state = {
-      height: new Animated.Value(Platform.OS === 'ios' ? props.statusbarHeight : 0),
-      opacity: new Animated.Value(0),
-      pulse: new Animated.Value(0)
-    }
-    this.timer = null
-  }
+	componentDidMount() {
+		if (this.props.visible === true) {
+			// Slide animation
+			requestAnimationFrame(() => {
+				Animated.parallel([
+					Animated.timing(this.state.height, {
+						toValue:
+							Platform.OS === 'ios'
+							? this.props.height + (this.props.statusbarHeight || STATUS_BAR_HEIGHT)
+							: this.props.height,
+						duration: SLIDE_DURATION
+					}),
+					Animated.timing(this.state.opacity, {
+						toValue: 1,
+						duration: SLIDE_DURATION
+					})
+				]).start();
+			});
+		}
+		// Pulse animation
+		this.timer = setInterval(() => {
+			if (this.props.pulse) {
+				if (Math.round(this.state.pulse._value) === 1) {
+					Animated.timing(this.state.pulse, {
+						toValue: 0,
+						duration: PULSE_DURATION
+					}).start();
+				} else {
+					Animated.timing(this.state.pulse, {
+						toValue: 1,
+						duration: PULSE_DURATION
+					}).start();
+				}
+			}
+		}, PULSE_DURATION);
+	}
 
-  componentDidMount() {
-    if (this.props.visible === true) {
-      // Slide animation
-      requestAnimationFrame(() => {
-        Animated.parallel([
-          Animated.timing(
-            this.state.height,
-            {
-              toValue: Platform.OS === 'ios' ? STATUS_BAR_HEIGHT + 24 : STATUS_BAR_HEIGHT,
-              duration: SLIDE_DURATION
-            }
-          ),
-          Animated.timing(
-            this.state.opacity,
-            {
-              toValue: 1,
-              duration: SLIDE_DURATION
-            }
-          )
-        ]).start()
-      })
-    }
-    // Pulse animation
-    this.timer = setInterval(() => {
-      if (this.props.pulse) {
-        if (Math.round(this.state.pulse._value) === 1) {
-          Animated.timing(
-            this.state.pulse,
-            {
-              toValue: 0,
-              duration: PULSE_DURATION
-            }
-          ).start()
-        } else {
-          Animated.timing(
-            this.state.pulse,
-            {
-              toValue: 1,
-              duration: PULSE_DURATION
-            }
-          ).start()
-        }
-      }
-    }, PULSE_DURATION)
-    if (this.props.statusbarHeight) STATUS_BAR_HEIGHT = this.props.statusbarHeight
-  }
+	componentWillUnmount() {
+		clearInterval(this.timer);
+	}
 
-  componentWillUnmount() {
-    clearInterval(this.timer)
-  }
+	componentWillReceiveProps(nextProps) {
+		if (nextProps.visible !== this.props.visible) {
+			if (nextProps.visible === true) {
+				// Show alert
+				requestAnimationFrame(() => {
+					Animated.parallel([
+						Animated.timing(this.state.height, {
+							toValue:
+								Platform.OS === 'ios'
+									? nextProps.height + (this.props.statusbarHeight || STATUS_BAR_HEIGHT)
+									: nextProps.height,
+							duration: SLIDE_DURATION
+						}),
+						Animated.timing(this.state.opacity, {
+							toValue: 1,
+							duration: SLIDE_DURATION
+						})
+					]).start();
+				});
+			}
+			if (nextProps.visible === false) {
+				// Hide alert
+				requestAnimationFrame(() => {
+					Animated.parallel([
+						Animated.timing(this.state.height, {
+							toValue: Platform.OS === 'ios' ? (this.props.statusbarHeight || STATUS_BAR_HEIGHT) : 0,
+							duration: SLIDE_DURATION
+						}),
+						Animated.timing(this.state.opacity, {
+							toValue: 0,
+							duration: SLIDE_DURATION
+						})
+					]).start();
+				});
+			}
+		}
+	}
 
-  componentWillReceiveProps(nextProps) {
-    if (nextProps.visible !== this.props.visible) {
-      if (nextProps.visible === true) {
-        // Show alert
-        requestAnimationFrame(() => {
-          Animated.parallel([
-            Animated.timing(
-              this.state.height,
-              {
-                toValue: Platform.OS === 'ios' ? nextProps.statusbarHeight + STATUS_BAR_HEIGHT : nextProps.statusbarHeight,
-                duration: SLIDE_DURATION
-              }
-            ),
-            Animated.timing(
-              this.state.opacity,
-              {
-                toValue: 1,
-                duration: SLIDE_DURATION
-              }
-            )
-          ]).start()
-        })
-      }
-      if (nextProps.visible === false) {
-        // Hide alert
-        requestAnimationFrame(() => {
-          Animated.parallel([
-            Animated.timing(
-              this.state.height,
-              {
-                toValue: Platform.OS === 'ios' ? this.props.statusbarHeight : 0,
-                duration: SLIDE_DURATION
-              }
-            ),
-            Animated.timing(
-              this.state.opacity,
-              {
-                toValue: 0,
-                duration: SLIDE_DURATION
-              }
-            )
-          ]).start()
-        })
-      }
-    }
-    if (this.props.statusbarHeight) STATUS_BAR_HEIGHT = this.props.statusbarHeight
-  }
-
-  render() {
-    const { containerStyles } = this.props;
-    const content = this.props.children ? this.props.children : (
-       <Animated.Text
-            style={[styles.text, {
-              color: this.props.color || styles.text.color,
-              opacity: this.props.pulse === 'text' ? this.state.pulse : 1
-            }]}
-            allowFontScaling={false}
-          >
-          {this.props.message}
-        </Animated.Text>
-    )
-    return (
-      <Animated.View style={[styles.view, {
-        height: this.state.height,
-        opacity: this.state.opacity,
-        backgroundColor: this.props.pulse === 'background' ? this.state.pulse.interpolate({
-          inputRange: [0, 1],
-          outputRange: [this.props.backgroundColor, this.props.highlightColor || saturate(this.props.backgroundColor, SATURATION)]
-        }) : this.props.backgroundColor
-      }]}>
-        <TouchableOpacity
-          style={[styles.touchableOpacity, containerStyles]}
-          onPress={this.props.onPress || null}
-          activeOpacity={ACTIVE_OPACITY}
-        >
-        {content}
-        </TouchableOpacity>
-      </Animated.View>
-    )
-  }
-
+	render() {
+		const content = this.props.children || (
+			<Animated.Text
+				style={[
+					styles.text,
+					{
+						color: this.props.color || styles.text.color,
+						opacity: this.props.pulse === 'text' ? this.state.pulse : 1
+					}
+				]}
+				allowFontScaling={false}
+			>
+				{this.props.message}
+			</Animated.Text>
+		);
+		return (
+			<Animated.View
+				style={[
+					styles.view,
+					this.props.style,
+					{
+						height: this.state.height,
+						opacity: this.state.opacity,
+						backgroundColor:
+							this.props.pulse === 'background'
+								? this.state.pulse.interpolate({
+										inputRange: [0, 1],
+										outputRange: [
+											this.props.backgroundColor,
+											this.props.highlightColor ||
+												saturate(this.props.backgroundColor, SATURATION)
+										]
+									})
+								: this.props.backgroundColor
+					}
+				]}
+			>
+				<TouchableOpacity
+					style={[styles.touchableOpacity, this.props.style]}
+					onPress={this.props.onPress || null}
+					activeOpacity={ACTIVE_OPACITY}
+				>
+					{content}
+				</TouchableOpacity>
+			</Animated.View>
+		);
+	}
 }
 
-let STATUS_BAR_HEIGHT = Platform.OS === 'ios' ? 20 : StatusBar.currentHeight
-const PULSE_DURATION = 1000
-const SLIDE_DURATION = 300
-const ACTIVE_OPACITY = 0.6
-const DEFAULT_BACKGROUND_COLOR = '#3DD84C'
-const SATURATION = 0.9
+let STATUS_BAR_HEIGHT = Platform.OS === 'ios' ? 20 : StatusBar.currentHeight;
+const PULSE_DURATION = 1000;
+const SLIDE_DURATION = 300;
+const ACTIVE_OPACITY = 0.6;
+const DEFAULT_BACKGROUND_COLOR = '#3DD84C';
+const SATURATION = 0.9;
 
 const styles = {
-  view: {
-    height: Platform.OS === 'ios' ? STATUS_BAR_HEIGHT * 2 : STATUS_BAR_HEIGHT,
-    backgroundColor: saturate('#3DD84C', SATURATION)
-  },
-  touchableOpacity: {
-    flex: 1,
-    display: 'flex',
-    height: STATUS_BAR_HEIGHT,
-    justifyContent: 'flex-end',
-    alignItems: 'center'
-  },
-  text: {
-    height: STATUS_BAR_HEIGHT,
-    fontSize: 14,
-    fontWeight: '400',
-    lineHeight: 20,
-    marginBottom: Platform.OS === 'ios' ? 4 : 0,
-    color: 'white'
-  }
-}
+	view: {
+		height: Platform.OS === 'ios' ? STATUS_BAR_HEIGHT * 2 : STATUS_BAR_HEIGHT,
+		backgroundColor: saturate('#3DD84C', SATURATION)
+	},
+	touchableOpacity: {
+		flex: 1,
+		display: 'flex',
+		height: STATUS_BAR_HEIGHT,
+		justifyContent: 'flex-end',
+		alignItems: 'center'
+	},
+	text: {
+		height: STATUS_BAR_HEIGHT,
+		fontSize: 14,
+		fontWeight: '400',
+		lineHeight: 20,
+		marginBottom: Platform.OS === 'ios' ? 4 : 0,
+		color: 'white'
+	}
+};
 
 StatusBarAlert.propTypes = {
-  visible: PropTypes.bool.isRequired,
-  message: PropTypes.string.isRequired,
-  pulse: PropTypes.oneOf(['text', 'background', null, false]),
-  backgroundColor: PropTypes.string,
-  highlightColor: PropTypes.string,
-  color: PropTypes.string,
-  statusbarHeight: PropTypes.number,
-  onPress: PropTypes.func
-}
+	visible: PropTypes.bool.isRequired,
+	message: PropTypes.string.isRequired,
+	pulse: PropTypes.oneOf(['text', 'background', null, false]),
+	backgroundColor: PropTypes.string,
+	highlightColor: PropTypes.string,
+	color: PropTypes.string,
+	height: PropTypes.number,
+	statusbarHeight: PropTypes.number,
+	onPress: PropTypes.func
+};
 
 StatusBarAlert.defaultProps = {
-  visible: false,
-  message: '',
-  pulse: false,
-  backgroundColor: DEFAULT_BACKGROUND_COLOR,
-  highlightColor: null,
-  color: styles.text.color,
-  statusbarHeight: STATUS_BAR_HEIGHT,
-  onPress: null
-}
+	visible: false,
+	message: '',
+	pulse: false,
+	backgroundColor: DEFAULT_BACKGROUND_COLOR,
+	highlightColor: null,
+	color: styles.text.color,
+	height: STATUS_BAR_HEIGHT,
+	statusbarHeight: STATUS_BAR_HEIGHT,
+	onPress: null
+};
 
 function saturate(color, percent) {
-  let R = parseInt(color.substring(1, 3), 16)
-  let G = parseInt(color.substring(3, 5), 16)
-  let B = parseInt(color.substring(5, 7), 16)
-  R = parseInt(R * percent)
-  G = parseInt(G * percent)
-  B = parseInt(B * percent)
-  R = (R < 255) ? R : 255
-  G = (G < 255) ? G : 255
-  B = (B < 255) ? B : 255
-  let r = ((R.toString(16).length == 1) ? '0' + R.toString(16) : R.toString(16))
-  let g = ((G.toString(16).length == 1) ? '0' + G.toString(16) : G.toString(16))
-  let b = ((B.toString(16).length == 1) ? '0' + B.toString(16) : B.toString(16))
-  return `#${r + g + b}`
+	let R = parseInt(color.substring(1, 3), 16);
+	let G = parseInt(color.substring(3, 5), 16);
+	let B = parseInt(color.substring(5, 7), 16);
+	R = parseInt(R * percent);
+	G = parseInt(G * percent);
+	B = parseInt(B * percent);
+	R = R < 255 ? R : 255;
+	G = G < 255 ? G : 255;
+	B = B < 255 ? B : 255;
+	let r = R.toString(16).length == 1 ? '0' + R.toString(16) : R.toString(16);
+	let g = G.toString(16).length == 1 ? '0' + G.toString(16) : G.toString(16);
+	let b = B.toString(16).length == 1 ? '0' + B.toString(16) : B.toString(16);
+	return `#${r + g + b}`;
 }
 
-export default StatusBarAlert
+export default StatusBarAlert;

--- a/index.js
+++ b/index.js
@@ -124,6 +124,18 @@ class StatusBarAlert extends Component {
   }
 
   render() {
+    const { containerStyles } = this.props;
+    const content = this.props.children ? this.props.children : (
+       <Animated.Text
+            style={[styles.text, {
+              color: this.props.color || styles.text.color,
+              opacity: this.props.pulse === 'text' ? this.state.pulse : 1
+            }]}
+            allowFontScaling={false}
+          >
+          {this.props.message}
+        </Animated.Text>
+    )
     return (
       <Animated.View style={[styles.view, {
         height: this.state.height,
@@ -134,19 +146,11 @@ class StatusBarAlert extends Component {
         }) : this.props.backgroundColor
       }]}>
         <TouchableOpacity
-          style={styles.touchableOpacity}
+          style={[styles.touchableOpacity, containerStyles]}
           onPress={this.props.onPress || null}
           activeOpacity={ACTIVE_OPACITY}
         >
-          <Animated.Text
-            style={[styles.text, {
-              color: this.props.color || styles.text.color,
-              opacity: this.props.pulse === 'text' ? this.state.pulse : 1
-            }]}
-            allowFontScaling={false}
-          >
-          {this.props.message}
-          </Animated.Text>
+        {content}
         </TouchableOpacity>
       </Animated.View>
     )


### PR DESCRIPTION
This is a continuation of https://github.com/gnestor/react-native-statusbar-alert/pull/13

It allows users to insert their own elements inside of a status bar alert (e.g. images). 

Usage:

```js
<StatusBarAlert
  visible={true}
  height={68}
  style={{
    padding: 5
  }}
>
  <Image
    style={{ width: 66, height: 58 }}
    source={{
      uri: 'https://facebook.github.io/react-native/img/header_logo.png'
    }}
  />
</StatusBarAlert>
```

It does require that a user pass a `height` prop. 

I also added a `style` prop to allow users to pass custom styles to the container `View` and `TouchableOpacity`.